### PR TITLE
Add HAVING support.

### DIFF
--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -38,7 +38,7 @@ module Database.Esqueleto
     -- $gettingstarted
 
     -- * @esqueleto@'s Language
-    Esqueleto( where_, on, groupBy, orderBy, asc, desc, limit, offset
+    Esqueleto( where_, on, groupBy, orderBy, asc, desc, limit, offset, having
              , sub_select, sub_selectDistinct, (^.), (?.)
              , val, isNothing, just, nothing, countRows, count, not_
              , (==.), (>=.), (>.), (<=.), (<.), (!=.), (&&.), (||.)

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -173,6 +173,9 @@ class (Functor query, Applicative query, Monad query) =>
   -- | @OFFSET@.  Usually used with 'limit'.
   offset :: Int64 -> query ()
 
+  -- | @HAVING@.
+  having :: expr (Value Bool) -> query ()
+
   -- | Execute a subquery @SELECT@ in an expression.  Returns a
   -- simple value so should be used only when the @SELECT@ query
   -- is guaranteed to return just one row.

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -517,6 +517,24 @@ main = do
                                   , (Entity p1k p1, Value 3)
                                   , (Entity p3k p3, Value 7) ]
 
+      it "GROUP BY works with HAVING" $
+        run $ do
+          p1k <- insert p1
+          p2k <- insert p2
+          p3k <- insert p3
+          replicateM_ 3 (insert $ BlogPost "" p1k)
+          replicateM_ 7 (insert $ BlogPost "" p3k)
+          ret <- select $
+                 from $ \(p `LeftOuterJoin` b) -> do
+                 on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                 let cnt = count (b ^. BlogPostId)
+                 groupBy (p ^. PersonId)
+                 having (cnt >. (val 0))
+                 orderBy [ asc cnt ]
+                 return (p, cnt)
+          liftIO $ ret `shouldBe` [ (Entity p1k p1, Value (3 :: Int))
+                                  , (Entity p3k p3, Value 7) ]
+
     describe "lists of values" $ do
       it "IN works for valList" $
         run $ do


### PR DESCRIPTION
I've added the `having` method to support `HAVING` clause with some aggregate functions like this:

``` .haskell
ret <- select $
       from $ \(p `LeftOuterJoin` b) -> do
       on (p ^. PersonId ==. b ^. BlogPostAuthorId)
       let cnt = count (b ^. BlogPostId)
       groupBy (p ^. PersonId)
       having (cnt >. (val 0))
       orderBy [ asc cnt ]
       return (p, cnt)
```

It generates

``` .sql
SELECT "Person"."id", "Person"."name", "Person"."age", COUNT("BlogPost"."id")
FROM "Person" LEFT OUTER JOIN "BlogPost" ON "Person"."id" = "BlogPost"."authorId"
GROUP BY "Person"."id"
HAVING COUNT("BlogPost"."id") > ?
ORDER BY COUNT("BlogPost"."id") ASC
```
