### PR TITLE
Adding some common functions 

### DIFF
--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -43,7 +43,7 @@ module Database.Esqueleto
              , val, isNothing, just, nothing, countRows, count, not_
              , (==.), (>=.), (>.), (<=.), (<.), (!=.), (&&.), (||.)
              , (+.), (-.), (/.), (*.)
-             , random_, sum_, round_, ceil_, floor_, avg_, min_, max_
+             , random_, sum_, round_, ceiling_, floor_, avg_, min_, max_
              , like, (%), concat_, (++.)
              , subList_select, subList_selectDistinct, valList
              , in_, notIn, exists, notExists

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -234,7 +234,7 @@ class (Functor query, Applicative query, Monad query) =>
 
   random_  :: PersistField a => expr (Value a)
   round_   :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)
-  ceil_    :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)
+  ceiling_ :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)
   floor_   :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)
   sum_     :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)
   min_     :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value b)

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -335,8 +335,8 @@ instance Esqueleto SqlQuery SqlExpr SqlBackend where
 
   random_  = unsafeSqlValue "RANDOM()"
   sum_     = unsafeSqlFunction "SUM"
-  round_   = unsafeSqlFunction "ROUND_"
-  ceil_    = unsafeSqlFunction "CEILING"
+  round_   = unsafeSqlFunction "ROUND"
+  ceiling_ = unsafeSqlFunction "CEILING"
   floor_   = unsafeSqlFunction "FLOOR"
   avg_     = unsafeSqlFunction "AVG"
   min_     = unsafeSqlFunction "MIN"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -276,6 +276,49 @@ main = do
                  return $ sum_ (p ^. PersonAge)
           liftIO $ ret `shouldBe` [ Value (36 + 17 + 17 :: Int) ]
 
+      it "works with sum_" $
+        run $ do
+          _ <- insert' p1
+          _ <- insert' p2
+          _ <- insert' p3
+          _ <- insert' p4
+          ret <- select $
+                 from $ \p->
+                 return $ avg_ (p ^. PersonAge)
+          liftIO $ ret `shouldBe` [ Value ((36 + 17 + 17) / 3 :: Double) ]
+
+      it "works with min_" $
+        run $ do
+          _ <- insert' p1
+          _ <- insert' p2
+          _ <- insert' p3
+          _ <- insert' p4
+          ret <- select $
+                 from $ \p->
+                 return $ min_ (p ^. PersonAge)
+          liftIO $ ret `shouldBe` [ Value (17 :: Int) ]
+
+      it "works with max_" $
+        run $ do
+          _ <- insert' p1
+          _ <- insert' p2
+          _ <- insert' p3
+          _ <- insert' p4
+          ret <- select $
+                 from $ \p->
+                 return $ max_ (p ^. PersonAge)
+          liftIO $ ret `shouldBe` [ Value (36 :: Int) ]
+
+      it "works with random_" $
+        run $ do
+          ret <- select $ return (random_ :: SqlExpr (Value Int))
+          return ()
+
+      it "works with round_" $
+        run $ do
+          ret <- select $ return $ round_ (val (16.2 :: Double))
+          liftIO $ ret `shouldBe` [ Value (16 :: Double) ]
+
       it "works with isNothing" $
         run $ do
           _   <- insert' p1


### PR DESCRIPTION
Hi again,
I was wondering if it would be ok to add some common SQL functions. Aggregates like sum, avg, min and max are common enough it seems like they could be part of the EDSL. The same goes for rounding functions (round, ceiling, floor). Random has different behavior depending on the backend, but then esqueleto already assumes the user doesn't care about backend abstraction.

There's other functions that could be useful, but which have a different syntax depending on the backend, like regular expressions. But I'm assuming backend-specific syntax would be relegated to separate packages, no?
