### PR TITLE
IN works for subList_select assumes ordering.

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -643,7 +643,8 @@ main = do
           ret <- select $
                  from $ \p -> do
                  let subquery =
-                       from $ \bp ->
+                       from $ \bp -> do
+                       orderBy [ asc (bp ^. BlogPostAuthorId) ]
                        return (bp ^. BlogPostAuthorId)
                  where_ (p ^. PersonId `in_` subList_select subquery)
                  return p


### PR DESCRIPTION
As referenced (here)[https://github.com/meteficha/esqueleto/issues/26], this test assumes a given order, which is however not made explicit. By pure chance, I guess, PostgreSQL returns the two rows in the inverse order. By making the ordering explicit, this test now passes, without influencing SQLite results.

Thanks!
