### PR TITLE
Increase upper bound on HSpec

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -90,7 +90,7 @@ test-suite test
     , containers
     , HUnit
     , QuickCheck
-    , hspec               >= 1.3 && < 1.8
+    , hspec               >= 1.3 && < 1.9
     , persistent-sqlite   >= 1.2 && < 1.4
     , persistent-template >= 1.2 && < 1.4
     , monad-control
@@ -104,7 +104,7 @@ test-suite test
         postgresql-simple     >= 0.2
       , postgresql-libpq      >= 0.6
       , persistent-postgresql >= 1.2.0
-    
+
     cpp-options: -DWITH_POSTGRESQL
 
   if flag(mysql)
@@ -114,4 +114,3 @@ test-suite test
       , persistent-mysql      >= 1.2.0
 
     cpp-options: -DWITH_MYSQL
-


### PR DESCRIPTION
This allows tests to be built and run when packaging for NixOS.
