### PR TITLE
Add function valJ (was keyE).

### DIFF
--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -81,7 +81,7 @@ module Database.Esqueleto
 
     -- * Helpers
   , valkey
-  , keyE
+  , valJ
 
     -- * Re-exports
     -- $reexports
@@ -377,14 +377,16 @@ valkey :: Esqueleto query expr backend =>
 valkey = val . Key . PersistInt64
 
 
--- | Given a value, lift the Key for that value into the query expression.
-keyE :: Esqueleto query expr backend =>
+-- | @valJ@ is like @val@ but for something that is already a @Value@. The use
+-- case it was written for was, given a @Value@ lift the @Key@ for that @Value@
+-- into the query expression in a type safe way. However, the implementation is
+-- more generic than that so we call it @valJ@.
+-- Its important to note that the input entity and the output entity are
+-- constrained to be the same by the type signature on the function.
+-- (<https://github.com/prowdsponsor/esqueleto/pull/69>)
+valJ :: Esqueleto query expr backend =>
         Value (Key entity) -> expr (Value (Key entity))
-keyE v =
-  valkey $
-    case (unKey . unValue) v of
-      PersistInt64 x -> x
-      _ -> error "Esqueleto.keyE: Impossible!"
+valJ = val . unValue
 
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Given a value, `keyE` lifts the `Key` for that value into the query expression.

```
keyE :: Esqueleto query expr backend =>
        Value (Key entity) -> expr (Value (Key entity))
```

This function (not totally happy with the name) solves a particular problem I met in my code base. I have a function `unValueKey` like this:

```
unValueKey :: Value (Key entity) -> Int64
unValueKey k =
    case (unKey . unValue) k of
        PersistInt64 x -> x
        _ -> error "unValueKey : Bad PersistValue."
```

and some times in a `where_` clause I would do:

```
  t ^. TableChairId ==.  valkey (unValueKey kid)
```

The problem is the composition of `valkey` with `unValueKey`. Given this function composition, GHC infers a type of:

```
Esqueleto query expr backend => Value (Key entity1) -> expr (Value (Key entity))
```

which does not constrain the `entity` type parameter of the output to be the same as the input. Without that constraint, the above is non-sensical.

To fix this, the type signature of `keyE` requires that input and output `entity` type paramer are identical.

I would have added a test, but I really don't think this can go wrong :-).
