### PR TITLE
Fix entityDB typo

### DIFF
--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -970,7 +970,7 @@ instance PersistEntity a => SqlSelect (SqlExpr (Entity a)) (Entity a) where
       where
         process ed = uncommas $
                      map ((name <>) . fromDBName info) $
-                     (entityID ed:) $
+                     (entityDB ed:) $
                      map fieldDB $
                      entityFields ed
         -- 'name' is the biggest difference between 'RawSql' and


### PR DESCRIPTION
Hi, this fixes the following error I had while trying to install esqueleto >= 2.0:

```
[3 of 4] Compiling Database.Esqueleto.Internal.Sql ( src/Database/Esqueleto/Internal/Sql.hs, dist/dist-sandbox-d141fbd5/build/Database/Esqueleto/Internal/Sql.o )

src/Database/Esqueleto/Internal/Sql.hs:973:23:
    Not in scope: ‘entityID’
    Perhaps you meant one of these:
      ‘entityId’ (imported from Database.Esqueleto.Internal.PersistentImport),
      ‘entityDB’ (imported from Database.Esqueleto.Internal.PersistentImport)
cabal: Error: some packages failed to install:
esqueleto-2.0.0 failed during the building phase. The exception was:
ExitFailure 1
```
