### PR TITLE
Add support for lower() function

### DIFF
--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -44,7 +44,7 @@ module Database.Esqueleto
              , (==.), (>=.), (>.), (<=.), (<.), (!=.), (&&.), (||.)
              , (+.), (-.), (/.), (*.)
              , random_, round_, ceiling_, floor_
-             , min_, max_, sum_, avg_
+             , min_, max_, sum_, avg_, lower_
              , coalesce, coalesceDefault
              , like, (%), concat_, (++.)
              , subList_select, subList_selectDistinct, valList

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -255,6 +255,7 @@ class (Functor query, Applicative query, Monad query) =>
   min_     :: (PersistField a) => expr (Value a) -> expr (Value (Maybe a))
   max_     :: (PersistField a) => expr (Value a) -> expr (Value (Maybe a))
   avg_     :: (PersistField a, PersistField b) => expr (Value a) -> expr (Value (Maybe b))
+  lower_   :: (PersistField a, IsString a) => expr (Value a) -> expr (Value a)
 
   -- | @COALESCE@ function. Evaluates the arguments in order and
   -- returns the value of the first non-NULL expression, or NULL

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -368,13 +368,15 @@ instance Esqueleto SqlQuery SqlExpr SqlBackend where
   (*.)  = unsafeSqlBinOp " * "
 
   random_  = unsafeSqlValue "RANDOM()"
-  sum_     = unsafeSqlFunction "SUM"
   round_   = unsafeSqlFunction "ROUND"
   ceiling_ = unsafeSqlFunction "CEILING"
   floor_   = unsafeSqlFunction "FLOOR"
-  avg_     = unsafeSqlFunction "AVG"
+
+  sum_     = unsafeSqlFunction "SUM"
   min_     = unsafeSqlFunction "MIN"
   max_     = unsafeSqlFunction "MAX"
+  avg_     = unsafeSqlFunction "AVG"
+  lower_   = unsafeSqlFunction "LOWER"
 
   coalesce              = unsafeSqlFunction "COALESCE"
   coalesceDefault exprs = unsafeSqlFunction "COALESCE" . (exprs ++) . return . just

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -44,6 +44,7 @@ import Test.Hspec
 import qualified Control.Monad.Trans.Resource as R
 import qualified Data.Set as S
 import qualified Data.List as L
+import Data.Char (toLower, toUpper)
 
 
 -- Test schema
@@ -373,6 +374,25 @@ main = do
                  from $ \p->
                  return $ joinV $ max_ (p ^. PersonAge)
           liftIO $ ret `shouldBe` [ Value $ Just (36 :: Int) ]
+
+      it "works with lower_" $
+        run $ do
+          p1e <- insert' p1
+          p2e@(Entity _ bob) <- insert' $ Person "bob" (Just 36) Nothing   1
+
+          -- lower(name) == 'john'
+          ret <- select $
+                 from $ \p-> do
+                 where_ (lower_ (p ^. PersonName) ==. val (map toLower $ personName p1))
+                 return p
+          liftIO $ ret `shouldBe` [ p1e ]
+
+          -- name == lower('BOB')
+          ret <- select $
+                 from $ \p-> do
+                 where_ (p ^. PersonName ==. lower_ (val $ map toUpper $ personName bob))
+                 return p
+          liftIO $ ret `shouldBe` [ p2e ]
 
       it "works with random_" $
         run $ do


### PR DESCRIPTION
This should enable the use of the lower function similar to the one described here: http://www.postgresql.org/docs/9.4/static/functions-string.html

Please let me know if you'd like to see some modifications made to this PR.

(also lightly reordered src/Database/Esqueleto/Internal/Sql.hs order of function declarations to be consistent across the various files in the project)