### PR TITLE
Don't match on clauses with cross joins

### DIFF
--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -550,6 +550,7 @@ data JoinKind =
   | LeftOuterJoinKind  -- ^ @LEFT OUTER JOIN@
   | RightOuterJoinKind -- ^ @RIGHT OUTER JOIN@
   | FullOuterJoinKind  -- ^ @FULL OUTER JOIN@
+    deriving Eq
 
 
 -- | (Internal) Functions that operate on types (that should be)

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -152,7 +152,9 @@ collectOnClauses = go []
           matchR = (\r' -> FromJoin l k r' onClause) <$> tryMatch expr r
           matchL = (\l' -> FromJoin l' k r onClause) <$> tryMatch expr l
           matchC = case onClause of
-                     Nothing -> return (FromJoin l k r (Just expr))
+                     Nothing | k /= CrossJoinKind
+                               -> return (FromJoin l k r (Just expr))
+                             | otherwise -> mzero
                      Just _  -> mzero
     tryMatch _ _ = mzero
 


### PR DESCRIPTION
So far, on clauses could be matched with cross joins. This patch changes it to skip them