### PR TITLE
fix rendering of joins

### DIFF
--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -390,7 +390,8 @@ infixl 6 +., -.
 infixr 5 ++.
 infix  4 ==., >=., >., <=., <., !=.
 infixr 3 &&., =., +=., -=., *=., /=.
-infixr 2 ||., `InnerJoin`, `CrossJoin`, `LeftOuterJoin`, `RightOuterJoin`, `FullOuterJoin`, `like`
+infixr 2 ||., `like`
+infixl 2 `InnerJoin`, `CrossJoin`, `LeftOuterJoin`, `RightOuterJoin`, `FullOuterJoin`
 
 -- | Syntax sugar for 'case_'.
 --

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -934,19 +934,20 @@ makeFrom info mode fs = ret
   where
     ret = case collectOnClauses fs of
             Left expr -> throw $ mkExc expr
-            Right fs' -> keyword $ uncommas' (map (mk Never mempty) fs')
+            Right fs' -> keyword $ uncommas' (map (mk Never) fs')
     keyword = case mode of
                 UPDATE -> id
                 _      -> first ("\nFROM " <>)
 
-    mk _     onClause (FromStart i def) = base i def <> onClause
-    mk paren onClause (FromJoin lhs kind rhs monClause) =
+    mk _     (FromStart i def) = base i def
+    mk paren (FromJoin lhs kind rhs monClause) =
       first (parensM paren) $
-      mconcat [ mk Parens onClause lhs
+      mconcat [ mk Never lhs
               , (fromKind kind, mempty)
-              , mk Never (maybe mempty makeOnClause monClause) rhs
+              , mk Parens rhs
+              , maybe mempty makeOnClause monClause
               ]
-    mk _ _ (OnClause _) = error "Esqueleto/Sql/makeFrom: never here (is collectOnClauses working?)"
+    mk _ (OnClause _) = error "Esqueleto/Sql/makeFrom: never here (is collectOnClauses working?)"
 
     base ident@(I identText) def =
       let db@(DBName dbText) = entityDB def

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -439,6 +439,19 @@ main = do
             retArt `shouldBe` article
             retTag `shouldBe` tag
 
+      it "respects the associativity of joins" $
+        run $ do
+            insert' p1
+            ps <- select . from $
+                      \((p :: SqlExpr (Entity Person))
+                       `LeftOuterJoin`
+                        (( q :: SqlExpr (Entity Person))
+                         `InnerJoin` (r :: SqlExpr (Entity Person)))) -> do
+                on (val False) -- Inner join is empty
+                on (val True)
+                return p
+            liftIO $ (entityVal <$> ps) `shouldBe` [p1]
+
     describe "select/where_" $ do
       it "works for a simple example with (==.)" $
         run $ do


### PR DESCRIPTION
Esqueleto exhibits strange behaviour with respect to joins. All joins seem to be left-associated even though the join Constructors are right associative. Explicitly adding parenthesis to left-associate the constructors adds seemingly superfluous parenthesis to the generated SQL. On the other hand there is no way to generate right-associated joins in the SQL.
This pullrequest takes a stab at fixing this. 
While the tests run though fine,  I'm a bit unsure about this. I don't understand SQL well enough to be certain that this is correct in all cases.

This is related to #8 

The downside of this patch is that the default associativity of the join operators now leads to different SQL code, e.g.

```haskell
foo = from $ \((p1 :: SqlExpr (Entity DB.Product))
              `InnerJoin` (p2 :: SqlExpr (Entity DB.Product))
              `InnerJoin` (p3 :: SqlExpr (Entity DB.Product))) -> do
    on (p3 ^. DB.ProductName ==. p1 ^. DB.ProductName)
    on (p2 ^. DB.ProductName ==. p1 ^. DB.ProductName)
    return ( p1 ^. DB.ProductName
           , p2 ^. DB.ProductName
           , p3 ^. DB.ProductName
           )
```

used to compile into 

```sql
SELECT "product"."name", "product2"."name", "product3"."name"
FROM "product" INNER JOIN "product" AS "product2" ON "product2"."name" = "product"."name" INNER JOIN "product" AS "product3" ON "product3"."name" = "product"."name"
```

But after this patch it becomes

```sql
SELECT "product"."name", "product2"."name", "product3"."name"
FROM "product" INNER JOIN ("product" AS "product2" INNER JOIN "product" AS "product3" ON "product3"."name" = "product"."name") ON "product2"."name" = "product"."name"
```

However, this is arguably the correct behaviour, as long as InnerJoin etc. are right-associative. Changing the associativity to infixl 2 restores the old behaviour and seems more intuitive to begin with, but can change the type of existing code.


