### PR TITLE
remove Control.Applicative warning

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -17,7 +17,6 @@
  #-}
 module Main (main) where
 
-import Control.Applicative ((<$>))
 import Control.Exception (IOException)
 import Control.Monad (replicateM, replicateM_)
 import Control.Monad.IO.Class (MonadIO(liftIO))


### PR DESCRIPTION
since we depend on base >= 4.6 not going to support older versions
anyways.