### PR TITLE
distinctOnOrderBy takes a 2nd argument for extra order columns

### DIFF
--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -229,6 +229,7 @@ class (Functor query, Applicative query, Monad query) =>
   -- ON@ to be the first ones to appear on a @ORDER BY@.  This is
   -- not managed automatically by esqueleto, keeping its spirit
   -- of trying to be close to raw SQL.
+  -- However, there is a convenience function `distinctOnOrderBy`
   --
   -- Supported by PostgreSQL only.
   --
@@ -245,20 +246,20 @@ class (Functor query, Applicative query, Monad query) =>
   -- 'orderBy'.  In other words,
   --
   -- @
-  -- 'distinctOnOrderBy' [asc foo, desc bar, desc quux] $ do
+  -- 'distinctOnOrderBy' [asc foo, desc bar] [desc quux] $ do
   --   ...
   -- @
   --
   -- is the same as:
   --
   -- @
-  -- 'distinctOn' [don foo, don  bar, don  quux] $ do
+  -- 'distinctOn' [don foo, don  bar] $ do
   --   'orderBy'  [asc foo, desc bar, desc quux]
   --   ...
   -- @
   --
   -- /Since: 2.2.4/
-  distinctOnOrderBy :: [expr OrderBy] -> query a -> query a
+  distinctOnOrderBy :: [expr OrderBy] -> [expr OrderBy] -> query a -> query a
 
   -- | @ORDER BY random()@ clause.
   --

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -404,9 +404,9 @@ instance Esqueleto SqlQuery SqlExpr SqlBackend where
   distinct         act = Q (W.tell mempty { sdDistinctClause = DistinctStandard }) >> act
   distinctOn exprs act = Q (W.tell mempty { sdDistinctClause = DistinctOn exprs }) >> act
   don = EDistinctOn
-  distinctOnOrderBy exprs act =
-    distinctOn (toDistinctOn <$> exprs) $ do
-      orderBy exprs
+  distinctOnOrderBy dords ords act =
+    distinctOn (toDistinctOn <$> dords) $ do
+      orderBy $ dords <> ords
       act
     where
       toDistinctOn :: SqlExpr OrderBy -> SqlExpr DistinctOn

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -850,7 +850,7 @@ main = do
             act
       it "works on a slightly less simple example (distinctOnOrderBy)" $ do
         slightlyLessSimpleTest $ \bp ->
-          distinctOnOrderBy [asc (bp ^. BlogPostAuthorId), asc (bp ^. BlogPostTitle)]
+          distinctOnOrderBy [asc (bp ^. BlogPostAuthorId), asc (bp ^. BlogPostTitle)] []
 #endif
 
     describe "coalesce/coalesceDefault" $ do


### PR DESCRIPTION
a hanging list is a low overhead

The first query of ours that I looked at had 2 columns in Distinct On and 3 in Order By, so the first 2 would go in the first argument and the 3rd would go in the 2nd. That API would seem to match the semantics

The DISTINCT ON expression(s) must match the leftmost ORDER BY expression(s).

My other option would be to put the 3rd column in a new orderBy clause, but the semantics of multiple orderBy clauses are not clear. Perhaps if it just needs to be well documented that I can add the third column that way.

Another option instead of a 2nd list argument would be something combinator based

    (distinctOnOrderBy [asc foo, desc bar] `extraOrderBy` [desc quux]) $ do

But I think there is too much orderBy stuff then.

Note: if you merged this PR you could do a minor version release and just deprecate 2.2.4
