### PR TITLE
Fix typo in haddock for `in_`

### DIFF
--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -471,7 +471,7 @@ class (Functor query, Applicative query, Monad query) =>
   -- @
   -- select $
   -- 'from' $ \\person -> do
-  -- 'where_' $ person '^.' PersonId `in_` 'valList' personIds
+  -- 'where_' $ person '^.' PersonId ``in_'` 'valList' personIds
   -- return person
   -- @
   --


### PR DESCRIPTION
The current haddock does not show the correct usage of `in_` because of missing backticks.