### PR TITLE
Fix update docs to have a slash

### DIFF
--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -927,7 +927,7 @@ deleteCount = rawEsqueleto DELETE
 -- Example of usage:
 --
 -- @
--- 'update' $ \p -> do
+-- 'update' $ \\p -> do
 -- 'set' p [ PersonAge '=.' 'just' ('val' thisYear) -. p '^.' PersonBorn ]
 -- 'where_' $ isNothing (p '^.' PersonAge)
 -- @


### PR DESCRIPTION
I know you know, but for the sake of others:

https://artyom.me/haddock-mistakes

@ / @ blocks in Haddock aren't verbatim, so you need to escape the slash in an anonymous function. Very annoying.
