### PR TITLE
Adjust for upcoming split db change

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -66,7 +66,7 @@ library
       base                 >= 4.5     && < 4.9
     , bytestring
     , text                 >= 0.11    && < 1.3
-    , persistent           >= 2.1.1.7 && < 2.3
+    , persistent           >= 2.5 && < 2.6
     , transformers         >= 0.2
     , unordered-containers >= 0.2
     , tagged               >= 0.2

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -430,8 +430,9 @@ valJ = val . unValue
 
 -- | Synonym for 'Database.Persist.Store.delete' that does not
 -- clash with @esqueleto@'s 'delete'.
-deleteKey :: ( PersistStore (PersistEntityBackend val)
+deleteKey :: ( PersistStore backend
+             , BaseBackend backend ~ PersistEntityBackend val
              , MonadIO m
              , PersistEntity val )
-          => Key val -> ReaderT (PersistEntityBackend val) m ()
+          => Key val -> ReaderT backend m ()
 deleteKey = Database.Persist.delete

--- a/src/Database/Esqueleto/Internal/PersistentImport.hs
+++ b/src/Database/Esqueleto/Internal/PersistentImport.hs
@@ -10,4 +10,4 @@ import Database.Persist.Sql hiding
   , selectKeysList, deleteCascadeWhere, (=.), (+=.), (-=.), (*=.), (/=.)
   , (==.), (!=.), (<.), (>.), (<=.), (>=.), (<-.), (/<-.), (||.)
   , listToJSON, mapToJSON, getPersistMap, limitOffsetOrder, selectSource
-  , update )
+  , update , count )

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -9,6 +9,7 @@
            , UndecidableInstances
            , ScopedTypeVariables
            , InstanceSigs
+           , Rank2Types
  #-}
 -- | This is an internal module, anything exported by this module
 -- may change without a major version bump.  Please use only
@@ -873,7 +874,7 @@ runSource src = src C.$$ CL.consume
 
 -- | (Internal) Execute an @esqueleto@ statement inside
 -- @persistent@'s 'SqlPersistT' monad.
-rawEsqueleto :: ( MonadIO m, SqlSelect a r, IsPersistBackend backend, BaseBackend backend ~ SqlBackend)
+rawEsqueleto :: ( MonadIO m, SqlSelect a r, IsSqlBackend backend)
            => Mode
            -> SqlQuery a
            -> R.ReaderT backend m Int64
@@ -962,7 +963,7 @@ builderToText = TL.toStrict . TLB.toLazyTextWith defaultChunkSize
 -- possible but tedious), you may just turn on query logging of
 -- @persistent@.
 toRawSql
-  :: (IsPersistBackend backend, BaseBackend backend ~ SqlBackend, SqlSelect a r)
+  :: (IsSqlBackend backend, SqlSelect a r)
   => Mode -> (backend, IdentState) -> SqlQuery a -> (TLB.Builder, [PersistValue])
 toRawSql mode (conn, firstIdentState) query =
   let ((ret, sd), finalIdentState) =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,3 @@
 resolver: lts-5.1
-packages:
-- location:
-    git: git@github.com:pseudonom/persistent
-    commit: 6f403f5cb12351a51491a4ed6d1eccfa40524ebb
-  subdirs:
-  - persistent
+extra-deps:
+  - persistent-2.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,6 @@ resolver: lts-5.1
 packages:
 - location:
     git: git@github.com:pseudonom/persistent
-    commit: 041eb7346cf5b597d8d6c67dc86dfc55d76acce3
+    commit: 6f403f5cb12351a51491a4ed6d1eccfa40524ebb
   subdirs:
   - persistent

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,7 @@
 resolver: lts-5.1
+packages:
+- location:
+    git: git@github.com:pseudonom/persistent
+    commit: 041eb7346cf5b597d8d6c67dc86dfc55d76acce3
+  subdirs:
+  - persistent

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1396,10 +1396,11 @@ main = do
 
 
 insert' :: ( Functor m
-           , PersistStore (PersistEntityBackend val)
+           , BaseBackend backend ~ PersistEntityBackend val
+           , PersistStore backend
            , MonadIO m
            , PersistEntity val )
-        => val -> ReaderT (PersistEntityBackend val) m (Entity val)
+        => val -> ReaderT backend m (Entity val)
 insert' v = flip Entity v <$> insert v
 
 


### PR DESCRIPTION
Adjusts `esqueleto` to work with upcoming split read and write DBs. https://github.com/yesodweb/persistent/pull/546
