### PR TITLE
esqueleto.cabal: Bump upper dependency limit for base

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -63,7 +63,7 @@ library
   other-modules:
     Database.Esqueleto.Internal.PersistentImport
   build-depends:
-      base                 >= 4.5     && < 4.9
+      base                 >= 4.5     && < 4.10
     , bytestring
     , text                 >= 0.11    && < 1.3
     , persistent           >= 2.1.1.7 && < 2.3


### PR DESCRIPTION
Ghc 8.0 ships with base 4.9.
