### PR TITLE
Add unsafeSqlCastAs for CAST( val AS type) sql, with test

### DIFF
--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -34,6 +34,7 @@ module Database.Esqueleto.Internal.Sql
   , unsafeSqlBinOp
   , unsafeSqlBinOpComposite
   , unsafeSqlValue
+  , unsafeSqlCastAs
   , unsafeSqlFunction
   , unsafeSqlExtractSubField
   , UnsafeSqlFunctionArgument
@@ -702,6 +703,13 @@ unsafeSqlFunctionParens name arg =
           uncommas' $ map (\(ERaw p f) -> first (parensM p) (f info)) $ toArgList arg
     in (name <> parens argsTLB, argsVals)
 
+
+-- | explicit cast using CAST(value as type)
+unsafeSqlCastAs :: T.Text -> SqlExpr (Value a) -> SqlExpr (Value b)
+unsafeSqlCastAs t (ERaw p f) =
+  ERaw Never $ \info ->
+    let (b, v) = f info
+    in ("CAST" <> parens ( parensM p b <> " AS " <> TLB.fromText t), v )
 
 class UnsafeSqlFunctionArgument a where
   toArgList :: a -> [SqlExpr (Value ())]


### PR DESCRIPTION
Provides a more flexible method then 
https://github.com/prowdsponsor/esqueleto/pull/119
can be used to support constants such as CAST( '12.3' AS real) 
or using in expressions such as CAST((timestamp '2001-11-11 09:11:25' + interval '1 hour' ) as time)
