### PR TITLE
Updates for persistent-2.5 and base-4.9

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -63,7 +63,7 @@ library
   other-modules:
     Database.Esqueleto.Internal.PersistentImport
   build-depends:
-      base                 >= 4.5     && < 4.9
+      base                 >= 4.5     && < 5
     , bytestring
     , text                 >= 0.11    && < 1.3
     , persistent           >= 2.1.1.7 && < 2.6

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -66,7 +66,7 @@ library
       base                 >= 4.5     && < 4.9
     , bytestring
     , text                 >= 0.11    && < 1.3
-    , persistent           >= 2.1.1.7 && < 2.3
+    , persistent           >= 2.1.1.7 && < 2.6
     , transformers         >= 0.2
     , unordered-containers >= 0.2
     , tagged               >= 0.2

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,5 +1,5 @@
 name:                esqueleto
-version:             2.4.3
+version:             2.5
 synopsis:            Type-safe EDSL for SQL queries on persistent backends.
 homepage:            https://github.com/prowdsponsor/esqueleto
 license:             BSD3

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -430,8 +430,8 @@ valJ = val . unValue
 
 -- | Synonym for 'Database.Persist.Store.delete' that does not
 -- clash with @esqueleto@'s 'delete'.
-deleteKey :: ( PersistStore (PersistEntityBackend val)
-             , MonadIO m
-             , PersistEntity val )
-          => Key val -> ReaderT (PersistEntityBackend val) m ()
+deleteKey :: ( PersistStore backend
+             , PersistRecordBackend val backend
+             , MonadIO m )
+          => Key val -> ReaderT backend m ()
 deleteKey = Database.Persist.delete

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -74,13 +74,11 @@ class (Functor query, Applicative query, Monad query) =>
   --   In the end, 'fromFinish' is called to materialize the
   --   @JOIN@.
   fromStart
-    :: ( PersistEntity a
-       , PersistEntityBackend a ~ backend )
+    :: PersistRecordBackend a backend
     => query (expr (PreprocessedFrom (expr (Entity a))))
   -- | (Internal) Same as 'fromStart', but entity may be missing.
   fromStartMaybe
-    :: ( PersistEntity a
-       , PersistEntityBackend a ~ backend )
+    :: PersistRecordBackend a backend
     => query (expr (PreprocessedFrom (expr (Maybe (Entity a)))))
   -- | (Internal) Do a @JOIN@.
   fromJoin
@@ -926,8 +924,7 @@ class ToBaseId ent where
 -- @
 -- person
 --   :: ( Esqueleto query expr backend
---      , PersistEntity Person
---      , PersistEntityBackend Person ~ backend
+--      , PersistRecordBackend Person backend
 --      ) => expr (Entity Person)
 -- (person, blogPost)
 --   :: (...) => (expr (Entity Person), expr (Entity BlogPost))
@@ -1054,14 +1051,12 @@ class Esqueleto query expr backend => FromPreprocess query expr backend a where
   fromPreprocess :: query (expr (PreprocessedFrom a))
 
 instance ( Esqueleto query expr backend
-         , PersistEntity val
-         , PersistEntityBackend val ~ backend
+         , PersistRecordBackend val backend
          ) => FromPreprocess query expr backend (expr (Entity val)) where
   fromPreprocess = fromStart
 
 instance ( Esqueleto query expr backend
-         , PersistEntity val
-         , PersistEntityBackend val ~ backend
+         , PersistRecordBackend val backend
          ) => FromPreprocess query expr backend (expr (Maybe (Entity val))) where
   fromPreprocess = fromStartMaybe
 

--- a/src/Database/Esqueleto/Internal/PersistentImport.hs
+++ b/src/Database/Esqueleto/Internal/PersistentImport.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE TypeFamilies               #-}
 -- | Re-export "Database.Persist.Sql" without any clashes with
 -- @esqueleto@.
 module Database.Esqueleto.Internal.PersistentImport
   ( module Database.Persist.Sql
+#if ! MIN_VERSION_persistent(2,5,0)
+    , PersistRecordBackend
+#endif
   ) where
 
 import Database.Persist.Sql hiding
@@ -10,4 +16,8 @@ import Database.Persist.Sql hiding
   , selectKeysList, deleteCascadeWhere, (=.), (+=.), (-=.), (*=.), (/=.)
   , (==.), (!=.), (<.), (>.), (<=.), (>=.), (<-.), (/<-.), (||.)
   , listToJSON, mapToJSON, getPersistMap, limitOffsetOrder, selectSource
-  , update )
+  , update, count )
+
+#if ! MIN_VERSION_persistent(2,5,0)
+type PersistRecordBackend record backend = (PersistEntity record, PersistEntityBackend record ~ backend)
+#endif

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1396,10 +1396,10 @@ main = do
 
 
 insert' :: ( Functor m
-           , PersistStore (PersistEntityBackend val)
-           , MonadIO m
-           , PersistEntity val )
-        => val -> ReaderT (PersistEntityBackend val) m (Entity val)
+           , PersistStore backend
+           , PersistRecordBackend val backend
+           , MonadIO m )
+        => val -> ReaderT backend m (Entity val)
 insert' v = flip Entity v <$> insert v
 
 


### PR DESCRIPTION
I've built this and run the tests (sqlite only) with lts-6.2, lts-6.2 plus forced persistent*-2.5.X, and nightly-2016-06-08 to bring GHC 8 into the mix.

I included a major version bump because of the type constraint on `deleteKey` changing.

Something has changed in the way `persistent` exports `count`, so I had to hide it explicitly, but I didn't get to the bottom of why.

Hope it helps!
